### PR TITLE
Harden firmware: fix reboot loops, wifi parsing, .env handling; add tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Unique identifier for this box. If unset, one is generated on first boot
+# and written to .env automatically (see boxid.js).
+BOX_ID=
+
+# Set to "test" to skip device-only side effects (e.g. chmod on the wifi
+# config). Used by the test suite.
+# NODE_ENV=

--- a/app.js
+++ b/app.js
@@ -1,42 +1,40 @@
-// require("dotenv").config();
 import dotenv from "dotenv";
 dotenv.config();
 
-import { host, logger } from "./logger.js";
+import { host, captureAndUpload } from "./logger.js";
 import { bleInit } from "./bluetooth.js";
 import { regenerateBoxId } from "./boxid.js";
+import { initSensors } from "./sensors.js";
 import { bashCmd, reboot, sleep } from "./utils.js";
+
+const HOUR = 1_000 * 60 * 60;
+const DAY = HOUR * 24;
 
 async function boot() {
   // Get/set BOX_ID
   if (!process.env.BOX_ID) {
-    const BOX_ID = await regenerateBoxId();
-    process.env.BOX_ID = BOX_ID;
-
-    startApp();
-  } else {
-    startApp();
+    process.env.BOX_ID = await regenerateBoxId();
   }
 
-  async function startApp() {
-    console.log("Starting app...");
-    logger();
-    bleInit();
+  console.log("Starting app...");
 
-    await sleep(10_000);
+  initSensors();
+  captureAndUpload();
+  bleInit();
 
-    // Take a snapshot every hour
-    setInterval(logger, 1_000 * 60 * 60);
+  await sleep(10_000);
 
-    // Reboot every day
-    setTimeout(reboot, 1_000 * 60 * 60 * 24);
+  // Take a snapshot every hour
+  setInterval(captureAndUpload, HOUR);
 
-    // Ping something every minute to keep wifi alive
-    setInterval(() => bashCmd(`ping ${host} -c 1`, true), 60_000);
+  // Reboot every day
+  setTimeout(reboot, DAY);
 
-    // Do a firmware update every 3 months-ish
-    // setTimeout(firmwareUpdate, 1_000 * 60 * 60 * 24 * 30 * 3);
-  }
+  // Ping the server every minute to keep wifi alive
+  setInterval(() => bashCmd(`ping ${host} -c 1`, true), 60_000);
+
+  // Do a firmware update every 3 months-ish
+  // setTimeout(firmwareUpdate, 1_000 * 60 * 60 * 24 * 30 * 3);
 }
 
 boot();

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,3 +1,3 @@
 module.exports = {
-  presets: [["@babel/preset-env", { targets: { node: "14" } }]],
+  presets: [["@babel/preset-env", { targets: { node: "18" } }]],
 };

--- a/bluetooth.js
+++ b/bluetooth.js
@@ -2,7 +2,7 @@ import bleno from "bleno";
 import fetch from "node-fetch";
 
 import { getSensorValues } from "./sensors.js";
-import { logger } from "./logger.js";
+import { captureAndUpload } from "./logger.js";
 import { regenerateBoxId } from "./boxid.js";
 import {
   reboot,
@@ -13,31 +13,42 @@ import {
 } from "./utils.js";
 import { wifiSettings } from "./wifi.js";
 
+// NOTE: trust model — this BLE control surface is intentionally
+// UNAUTHENTICATED. The box is provisioned in a physically trusted setup
+// phase, and short-range BLE proximity is treated as the trust boundary.
+// Anyone able to connect can set wifi, reboot, and trigger firmware/OS
+// updates. This is a known, accepted tradeoff for this device (see also the
+// world-writable wifi config in wifi.js). Do not expose this service beyond
+// short-range provisioning use.
+
+// Single-client provisioning queue: only one BLE client is expected to be
+// connected at a time, so this is shared process-wide.
 const messageQueue = [];
 const tx = new TextDecoder("utf-8");
 
-const getOnlineStatus = new Promise((resolve) => {
-  async function runCheck() {
-    try {
-      const response = await fetch("https://google.com");
-
-      resolve(response.ok);
-    } catch (e) {
-      resolve(false);
-    }
-  }
-
-  setTimeout(runCheck, 2000);
-});
-
-let firmwareVersion = "n/a";
-(async function getFirmwareVersion() {
+// Checked fresh on each subscribe so the reported status reflects current
+// connectivity rather than a value frozen at boot.
+async function checkOnlineStatus() {
   try {
-    firmwareVersion = await bashCmd("git rev-parse --short HEAD");
+    const response = await fetch("https://google.com");
+    return response.ok;
   } catch (e) {
-    console.log(e);
+    return false;
   }
-})();
+}
+
+// Resolved lazily and cached, so a client subscribing during early boot
+// still gets the real version once git has been queried.
+let firmwareVersionPromise;
+function getFirmwareVersion() {
+  if (!firmwareVersionPromise) {
+    firmwareVersionPromise = bashCmd("git rev-parse --short HEAD").catch((e) => {
+      console.log(e);
+      return "n/a";
+    });
+  }
+  return firmwareVersionPromise;
+}
 
 const uuid = "601202ac-16d1-4f74-819d-85788a5ad77a";
 
@@ -68,145 +79,162 @@ export function bleInit() {
   bleno.on("advertisingStart", function (error) {
     if (error) {
       console.log("Advertising start error:" + error);
-    } else {
-      console.log("Advertising start success");
-      bleno.setServices([
-        // Define a new service
-        new bleno.PrimaryService({
-          uuid: uuid,
-          characteristics: [
-            // Define a new characteristic within that service
-            new bleno.Characteristic({
-              value: null,
-              uuid: "34cd",
-              properties: ["notify", "read", "write"],
+      return;
+    }
 
-              // If the client subscribes, we send out a message every 1 second
-              onSubscribe: function (maxValueSize, updateValueCallback) {
-                console.log("Device subscribed");
-                clearInterval(this.intervalId);
-                clearInterval(this.sensorReadingIntervalId);
+    console.log("Advertising start success");
+    bleno.setServices([
+      // Define a new service
+      new bleno.PrimaryService({
+        uuid: uuid,
+        characteristics: [
+          // Define a new characteristic within that service
+          new bleno.Characteristic({
+            value: null,
+            uuid: "34cd",
+            properties: ["notify", "read", "write"],
 
-                this.intervalId = setInterval(function () {
-                  const message = messageQueue.splice(0, 1);
-                  if (message && message.length === 1) {
-                    console.log("about to send message", message[0]);
-                    updateValueCallback(
-                      Buffer.from(JSON.stringify(message[0]))
+            // If the client subscribes, we send out a message every 1 second
+            onSubscribe: function (maxValueSize, updateValueCallback) {
+              console.log("Device subscribed");
+              this.maxValueSize = maxValueSize;
+              clearInterval(this.intervalId);
+              clearInterval(this.sensorReadingIntervalId);
+
+              this.intervalId = setInterval(() => {
+                const message = messageQueue.splice(0, 1);
+                if (message && message.length === 1) {
+                  const payload = Buffer.from(JSON.stringify(message[0]));
+
+                  // BLE notifications can't exceed the negotiated MTU and we
+                  // don't fragment/reassemble — warn instead of silently
+                  // delivering a truncated payload.
+                  if (payload.length > this.maxValueSize) {
+                    console.warn(
+                      `Dropping BLE message '${message[0].action}': ` +
+                        `${payload.length}B exceeds MTU ${this.maxValueSize}B`
                     );
+                    return;
                   }
-                }, 1000);
 
-                function sendSensorReading() {
-                  messageQueue.push({
-                    action: "sensor-reading",
-                    data: getSensorValues(),
-                  });
+                  console.log("about to send message", message[0]);
+                  updateValueCallback(payload);
                 }
+              }, 1000);
 
-                // Broadcasting the sensor readings
-                this.sensorReadingIntervalId = setInterval(
-                  sendSensorReading,
-                  5000
-                );
-                sendSensorReading();
+              function sendSensorReading() {
+                messageQueue.push({
+                  action: "sensor-reading",
+                  data: getSensorValues(),
+                });
+              }
 
-                setTimeout(async () => {
-                  messageQueue.push({
-                    action: "box-id",
-                    data: process.env.BOX_ID,
-                  });
-                  messageQueue.push({
-                    action: "version",
-                    data: firmwareVersion,
-                  });
-                  messageQueue.push({
-                    action: "wifi-settings",
-                    data: wifiSettings.get(),
-                  });
+              // Broadcasting the sensor readings
+              this.sensorReadingIntervalId = setInterval(
+                sendSensorReading,
+                5000
+              );
+              sendSensorReading();
 
-                  const isOnline = await getOnlineStatus;
-                  messageQueue.push({
-                    action: "is-online",
-                    data: isOnline,
-                  });
-                }, 250);
-              },
+              setTimeout(async () => {
+                messageQueue.push({
+                  action: "box-id",
+                  data: process.env.BOX_ID,
+                });
+                messageQueue.push({
+                  action: "version",
+                  data: await getFirmwareVersion(),
+                });
+                messageQueue.push({
+                  action: "wifi-settings",
+                  data: wifiSettings.get(),
+                });
+                messageQueue.push({
+                  action: "is-online",
+                  data: await checkOnlineStatus(),
+                });
+              }, 250);
+            },
 
-              // If the client unsubscribes, we stop broadcasting the message
-              onUnsubscribe: function () {
-                console.log("Device unsubscribed");
-                clearInterval(this.intervalId);
-                clearInterval(this.sensorReadingIntervalId);
-              },
+            // If the client unsubscribes, we stop broadcasting the message
+            onUnsubscribe: function () {
+              console.log("Device unsubscribed");
+              clearInterval(this.intervalId);
+              clearInterval(this.sensorReadingIntervalId);
+            },
 
-              // Send a message back to the client with the characteristic's value
-              onReadRequest: function (offset, callback) {
-                console.log("Read request received");
-                callback(this.RESULT_SUCCESS, this.value || Buffer.from(""));
-              },
+            // Send a message back to the client with the characteristic's value
+            onReadRequest: function (offset, callback) {
+              console.log("Read request received");
+              callback(this.RESULT_SUCCESS, this.value || Buffer.from(""));
+            },
 
-              // Accept a new value for the characterstic's value
-              onWriteRequest: async function (
-                data,
-                offset,
-                withoutResponse,
-                callback
-              ) {
-                this.value = data;
+            // Accept a new value for the characterstic's value
+            onWriteRequest: async function (
+              data,
+              offset,
+              withoutResponse,
+              callback
+            ) {
+              this.value = data;
 
-                try {
-                  console.log("incoming write request");
+              try {
+                console.log("incoming write request");
 
-                  const dataAsString = tx.decode(this.value);
-                  console.log(dataAsString);
+                const dataAsString = tx.decode(this.value);
+                console.log(dataAsString);
 
-                  const json = JSON.parse(dataAsString);
-                  switch (json.action) {
-                    case "set-wifi": {
-                      wifiSettings.set(json.data);
-                      messageQueue.push({
-                        action: "wifi-settings",
-                        data: wifiSettings.get(),
-                      });
-                      break;
-                    }
-                    case "firmware-update": {
-                      firmwareUpdate();
-                      break;
-                    }
-                    case "os-update": {
-                      osUpdate();
-                      break;
-                    }
-                    case "reboot": {
-                      reboot();
-                      break;
-                    }
-                    case "shutdown": {
-                      shutdown();
-                      break;
-                    }
-                    case "take-snapshot": {
-                      logger();
-                      break;
-                    }
-                    case "regenerate-boxid": {
-                      await regenerateBoxId(json.id);
-                      reboot();
-                      break;
-                    }
+                const json = JSON.parse(dataAsString);
+                switch (json.action) {
+                  case "set-wifi": {
+                    wifiSettings.set(json.data);
+                    messageQueue.push({
+                      action: "wifi-settings",
+                      data: wifiSettings.get(),
+                    });
+                    break;
                   }
-                } catch (e) {
-                  console.log(e);
+                  case "firmware-update": {
+                    firmwareUpdate();
+                    break;
+                  }
+                  case "os-update": {
+                    osUpdate();
+                    break;
+                  }
+                  case "reboot": {
+                    reboot();
+                    break;
+                  }
+                  case "shutdown": {
+                    shutdown();
+                    break;
+                  }
+                  case "take-snapshot": {
+                    captureAndUpload();
+                    break;
+                  }
+                  case "regenerate-boxid": {
+                    await regenerateBoxId(json.data);
+                    reboot();
+                    break;
+                  }
+                  default: {
+                    console.log("Unknown action:", json.action);
+                    callback(this.RESULT_UNLIKELY_ERROR);
+                    return;
+                  }
                 }
 
                 callback(this.RESULT_SUCCESS);
-              },
-            }),
-          ],
-        }),
-      ]);
-    }
+              } catch (e) {
+                console.log(e);
+                callback(this.RESULT_UNLIKELY_ERROR);
+              }
+            },
+          }),
+        ],
+      }),
+    ]);
   });
 }

--- a/boxid.js
+++ b/boxid.js
@@ -1,9 +1,29 @@
 import fs from "fs/promises";
 import { v4 as uuidv4 } from "uuid";
 
+const ENV_PATH = "./.env";
+
+// Persist BOX_ID without destroying any other variables already in .env.
 export async function regenerateBoxId(manualId) {
   const BOX_ID = manualId || uuidv4();
-  await fs.writeFile("./.env", "BOX_ID=" + BOX_ID);
+  const line = `BOX_ID=${BOX_ID}`;
+
+  let existing = "";
+  try {
+    existing = await fs.readFile(ENV_PATH, "utf-8");
+  } catch (e) {
+    // No .env yet — we'll create it below.
+  }
+
+  let next;
+  if (/^BOX_ID=.*$/m.test(existing)) {
+    next = existing.replace(/^BOX_ID=.*$/m, line);
+  } else {
+    const prefix = existing && !existing.endsWith("\n") ? existing + "\n" : existing;
+    next = `${prefix}${line}\n`;
+  }
+
+  await fs.writeFile(ENV_PATH, next);
 
   return BOX_ID;
 }

--- a/boxid.test.js
+++ b/boxid.test.js
@@ -1,0 +1,51 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+import { regenerateBoxId } from "./boxid.js";
+
+// regenerateBoxId reads/writes "./.env" relative to cwd, so each test runs in
+// a throwaway temp directory.
+let tmpDir;
+let originalCwd;
+
+beforeEach(async () => {
+  originalCwd = process.cwd();
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "boxid-"));
+  process.chdir(tmpDir);
+});
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+test("creates .env with a manual id when none exists", async () => {
+  const id = await regenerateBoxId("manual-123");
+
+  expect(id).toBe("manual-123");
+  expect(await fs.readFile(".env", "utf-8")).toBe("BOX_ID=manual-123\n");
+});
+
+test("generates a uuid when no id is provided", async () => {
+  const id = await regenerateBoxId();
+
+  expect(id).toMatch(/^[0-9a-f-]{36}$/);
+  expect(await fs.readFile(".env", "utf-8")).toBe(`BOX_ID=${id}\n`);
+});
+
+test("replaces an existing BOX_ID while preserving other variables", async () => {
+  await fs.writeFile(".env", "FOO=1\nBOX_ID=old\nBAR=2\n");
+
+  await regenerateBoxId("new");
+
+  expect(await fs.readFile(".env", "utf-8")).toBe("FOO=1\nBOX_ID=new\nBAR=2\n");
+});
+
+test("appends BOX_ID when missing, normalizing a missing trailing newline", async () => {
+  await fs.writeFile(".env", "FOO=1");
+
+  await regenerateBoxId("z");
+
+  expect(await fs.readFile(".env", "utf-8")).toBe("FOO=1\nBOX_ID=z\n");
+});

--- a/logger.js
+++ b/logger.js
@@ -1,27 +1,28 @@
 import fetch from "node-fetch";
 import fs from "fs";
 
-import { reboot, takePicture } from "./utils.js";
+import { reboot, takePicture, sleep } from "./utils.js";
 import { getSensorValues } from "./sensors.js";
 
 export const host = "xn--vrhna-sra2k.no";
 
-function sleep(ms) {
-  return new Promise((r) => setTimeout(r, ms));
-}
+const SLEEP_WON = Symbol("sleep-won");
+const UPLOAD_WATCHDOG_MS = 60_000 * 3;
+const MAX_ATTEMPTS = 3;
 
-export async function logger() {
-  const sleepWon = "maybe";
+// Capture a snapshot and upload it to the API. Wrapped in a watchdog: if the
+// whole operation hangs far past any reasonable duration the device is
+// wedged, and a reboot is the only reliable recovery. That is the *only*
+// place a reboot is justified — transient upload failures retry/back off
+// inside captureAndUpload() instead of power-cycling the box.
+export async function captureAndUpload() {
   const res = await Promise.race([
-    logToApi(),
-    (async function () {
-      await sleep(60_000 * 3);
-      return sleepWon;
-    })(),
+    upload(),
+    sleep(UPLOAD_WATCHDOG_MS).then(() => SLEEP_WON),
   ]);
 
-  if (res === sleepWon) {
-    console.log("SLEEP WON");
+  if (res === SLEEP_WON) {
+    console.log("Snapshot upload timed out — rebooting (watchdog)");
     reboot();
     return;
   }
@@ -29,67 +30,75 @@ export async function logger() {
   return res;
 }
 
-async function logToApi() {
+async function upload() {
   try {
     await takePicture();
   } catch (err) {
     console.log("Could not take picture, continuing with old...");
   }
 
+  let imageBase64;
   try {
-    const imageBase64 = fs.readFileSync("./snapshot.jpg", {
-      encoding: "base64",
-    });
+    imageBase64 = fs.readFileSync("./snapshot.jpg", { encoding: "base64" });
+  } catch (err) {
+    console.log("No snapshot available to send, skipping this cycle");
+    return;
+  }
 
-    console.log("will send at " + new Date().toISOString());
-    console.log("--image with length", imageBase64.length);
-    console.log("--sensors", JSON.stringify(getSensorValues()));
-    console.log("--boxId", process.env.BOX_ID);
-
-    function send() {
-      return fetch(`https://${host}/api/graphql`, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({
-          query: `
-            mutation($input: AddSnapshotMutationInput!) {
-              snapshots {
-                add(input: $input) {
-                  success
-                }
+  function send() {
+    return fetch(`https://${host}/api/graphql`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        query: `
+          mutation($input: AddSnapshotMutationInput!) {
+            snapshots {
+              add(input: $input) {
+                success
               }
             }
-          `,
-          variables: {
-            input: {
-              boxId: process.env.BOX_ID,
-              image: imageBase64,
-              ...getSensorValues(),
-            },
+          }
+        `,
+        variables: {
+          input: {
+            boxId: process.env.BOX_ID,
+            image: imageBase64,
+            ...getSensorValues(),
           },
-        }),
-      });
-    }
-
-    const response = await send();
-
-    if (!response.ok) {
-      throw new Error(`Snapshot FAILED`);
-    }
-
-    const json = await response.json();
-
-    if (json.errors) {
-      console.log(JSON.stringify(json.errors, null, 1));
-      throw new Error(`Snapshot FAILED`);
-    }
-
-    console.log(`Snapshot sent`);
-  } catch (e) {
-    console.log("logger error ⛔️");
-    console.log(e);
-    void reboot();
+        },
+      }),
+    });
   }
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const response = await send();
+
+      if (!response.ok) {
+        throw new Error(`Snapshot FAILED (HTTP ${response.status})`);
+      }
+
+      const json = await response.json();
+
+      if (json.errors) {
+        console.log(JSON.stringify(json.errors, null, 1));
+        throw new Error("Snapshot FAILED (GraphQL errors)");
+      }
+
+      console.log(`Snapshot sent (boxId ${process.env.BOX_ID})`);
+      return;
+    } catch (e) {
+      console.log(`logger error ⛔️ (attempt ${attempt}/${MAX_ATTEMPTS})`);
+      console.log(e);
+
+      if (attempt < MAX_ATTEMPTS) {
+        // Exponential backoff: 1s, then 2s.
+        await sleep(1000 * 2 ** (attempt - 1));
+      }
+    }
+  }
+
+  console.log("Giving up on this snapshot; will retry next cycle");
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
   },
   "scripts": {
     "start": "node app.js",
-    "test": "jest --watch"
+    "test": "jest",
+    "test:watch": "jest --watch"
+  },
+  "engines": {
+    "node": ">=18"
   },
   "devDependencies": {
     "@babel/core": "^7.24.9",

--- a/sensors.js
+++ b/sensors.js
@@ -11,9 +11,6 @@ export function getSensorValues() {
   return values;
 }
 
-dht22.setMaxRetries(10);
-dht22.initialize(22, 4);
-
 async function readSensorValues() {
   try {
     const dht22values = await dht22.read(
@@ -28,5 +25,17 @@ async function readSensorValues() {
   }
 }
 
-readSensorValues();
-setInterval(readSensorValues, 1000);
+let started = false;
+
+// Side effects (GPIO init + polling) are kept out of module load so the
+// module can be imported off-device (e.g. in tests) without throwing.
+export function initSensors() {
+  if (started) return;
+  started = true;
+
+  dht22.setMaxRetries(10);
+  dht22.initialize(22, 4);
+
+  readSensorValues();
+  setInterval(readSensorValues, 1000);
+}

--- a/utils.test.js
+++ b/utils.test.js
@@ -1,0 +1,17 @@
+import { bashCmd } from "./utils.js";
+
+test("resolves with stdout", async () => {
+  await expect(bashCmd("echo hi", true)).resolves.toBe("hi");
+});
+
+test("strips newlines from multiline output", async () => {
+  await expect(bashCmd("printf 'a\\nb\\nc'", true)).resolves.toBe("abc");
+});
+
+test("rejects when the command exits non-zero", async () => {
+  const err = jest.spyOn(console, "error").mockImplementation(() => {});
+
+  await expect(bashCmd("exit 3", true)).rejects.toBeTruthy();
+
+  err.mockRestore();
+});

--- a/wifi.js
+++ b/wifi.js
@@ -2,20 +2,31 @@ import fs from "fs";
 
 import { bashCmd, reboot } from "./utils.js";
 
+// wpa_supplicant quoted strings can't contain a literal " or newline, so we
+// refuse those values rather than write a corrupt config file.
+const isUnsafeValue = (v) => typeof v !== "string" || /["\n\r]/.test(v);
+
 export const wifiSettings = {
   path: "/etc/wpa_supplicant/wpa_supplicant.conf",
   parseConfigContent: (content) => {
     try {
-      // Define the regex pattern to match the wifi configuration
-      // The pattern looks for "ssid" and "psk" keys followed by "=" and captures their respective values
-      const regex = /ssid="([^"]+)"\s+psk="([^"]+)"/g;
-      let match;
       const configs = [];
 
-      // Use a while loop to find all matches in the input text
-      while ((match = regex.exec(content)) !== null) {
-        // Push the captured groups into the configs array with the desired object structure
-        configs.push({ ssid: match[1], psk: match[2] });
+      // Parse each `network={ ... }` block independently so field order,
+      // extra fields, and open (psk-less) networks don't break parsing.
+      const blockRegex = /network=\{([^}]*)\}/g;
+      let block;
+      while ((block = blockRegex.exec(content)) !== null) {
+        const body = block[1];
+        const ssidMatch = body.match(/ssid="([^"]*)"/);
+        const pskMatch = body.match(/psk="([^"]*)"/);
+
+        if (ssidMatch) {
+          configs.push({
+            ssid: ssidMatch[1],
+            psk: pskMatch ? pskMatch[1] : "",
+          });
+        }
       }
 
       return configs;
@@ -30,14 +41,22 @@ update_config=1
 country=NO
 
 ${config
-  .map(
-    (c) => `network={
+  .filter((c) => {
+    if (isUnsafeValue(c.ssid) || (c.psk != null && isUnsafeValue(c.psk))) {
+      console.warn("Skipping invalid wifi entry", c);
+      return false;
+    }
+    return true;
+  })
+  .map((c) => {
+    const psk = c.psk == null ? "" : c.psk;
+    return `network={
   ssid="${c.ssid}"
-  psk="${c.psk}"
+  psk="${psk}"
 }
 
-`
-  )
+`;
+  })
   .join("")}`;
   },
   get() {
@@ -56,7 +75,12 @@ ${config
   },
 };
 
-// Ensure file access for wifi settings
+// NOTE: trust model — the wifi config is made world-writable so the
+// (non-root) app can rewrite credentials during BLE provisioning. Like the
+// unauthenticated BLE control surface (see bluetooth.js), this is an
+// accepted tradeoff for a device provisioned in a physically trusted setup
+// phase. The file contains the WiFi PSK in plaintext; treat physical/BLE
+// access to the box as full access.
 if (process.env.NODE_ENV !== "test") {
   bashCmd(`sudo chmod 666 ${wifiSettings.path}`);
 }

--- a/wifi.test.js
+++ b/wifi.test.js
@@ -73,3 +73,55 @@ network={
 
 `);
 });
+
+test("parses networks regardless of field order and extra fields", () => {
+  expect(
+    wifiSettings.parseConfigContent(`network={
+  scan_ssid=1
+  psk="secret"
+  ssid="myssid"
+  priority=1
+}`)
+  ).toEqual([{ ssid: "myssid", psk: "secret" }]);
+});
+
+test("parses open networks (no psk) with an empty psk", () => {
+  expect(
+    wifiSettings.parseConfigContent(`network={
+  ssid="openwifi"
+  key_mgmt=NONE
+}`)
+  ).toEqual([{ ssid: "openwifi", psk: "" }]);
+});
+
+test("returns an empty array when there are no networks", () => {
+  expect(wifiSettings.parseConfigContent("country=NO\n")).toEqual([]);
+  expect(wifiSettings.parseConfigContent("")).toEqual([]);
+});
+
+test("round-trips parse(toConfigContent(x))", () => {
+  const networks = [
+    { ssid: "one", psk: "two" },
+    { ssid: "three", psk: "four" },
+  ];
+  expect(
+    wifiSettings.parseConfigContent(wifiSettings.toConfigContent(networks))
+  ).toEqual(networks);
+});
+
+test("drops entries whose ssid/psk contain unsafe characters", () => {
+  const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+  const content = wifiSettings.toConfigContent([
+    { ssid: 'evil"\nnetwork={', psk: "x" },
+    { ssid: "safe", psk: "good" },
+  ]);
+
+  expect(content).not.toContain("evil");
+  expect(content).toContain('ssid="safe"');
+  expect(wifiSettings.parseConfigContent(content)).toEqual([
+    { ssid: "safe", psk: "good" },
+  ]);
+
+  warn.mockRestore();
+});


### PR DESCRIPTION
Code-review pass over the Pi sensor-box firmware.

## Trust model (documented, not changed)
The unauthenticated BLE control surface and the world-writable wifi config are kept as-is by design — the box is provisioned in a physically trusted, short-range setup phase, and BLE proximity is the trust boundary. Both are now documented with `NOTE: trust model` comments (`bluetooth.js`, `wifi.js`). If the process runs as root we can later tighten the wifi perms to `0600` and drop the `chmod`.

## Fixes
- **boxid**: `regenerateBoxId` now read-modify-writes `.env` instead of clobbering every other variable in it.
- **logger**: retry with exponential backoff on upload failure instead of rebooting on *any* error; reboot reserved for the genuine watchdog timeout; missing snapshot skips the cycle. Renamed `logger()` → `captureAndUpload()`.
- **bluetooth**: `is-online` checked live per subscribe (was frozen ~2s after boot); notifications guarded against the negotiated MTU instead of silently truncating; standardized message contract on `json.data`; firmware version resolved lazily (no boot race); write requests return `RESULT_UNLIKELY_ERROR` on parse failure / unknown action.
- **wifi**: per-`network{}` block parsing — order-independent, tolerates extra fields and open (psk-less) networks; rejects ssid/psk values containing `"`/newlines on write.
- **sensors**: GPIO init + polling moved behind `initSensors()` so the module is importable off-device.
- **tooling**: runnable `test` script (+ `test:watch`), `engines: node >=18`, babel target → 18, added `.env.example`.

## Tests
- Extended `wifi.test.js` (field-order independence, open networks, empty input, round-trip, unsafe-value filtering).
- New `boxid.test.js` (`.env` preservation behaviors, temp-dir isolated).
- New `utils.test.js` (`bashCmd` stdout / newline-stripping / non-zero exit).

All 14 tests pass (`npx jest`). `logger`/`bluetooth`/`sensors` are I/O- and hardware-bound and left untested deliberately — heavy mocking, low signal.

> Note: `bleno` is still pinned to a personal fork tracking branch HEAD (`github:hakonkrogh/bleno`) — a supply-chain/reproducibility risk flagged but not touched here; worth pinning to a commit SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)